### PR TITLE
Allow the feedstock to build with libfuse 3.x

### DIFF
--- a/recipe/fix-fuse3-configure.patch
+++ b/recipe/fix-fuse3-configure.patch
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -40,7 +40,7 @@
+ 
+ PKG_CHECK_MODULES([LIBCONFIG], [libconfig >= 1.5])
+ PKG_CHECK_MODULES([LIBUV], [libuv >= 1.18])
+-PKG_CHECK_MODULES([LIBFUSE], [fuse >= 2.9.7])
++PKG_CHECK_MODULES([LIBFUSE], [fuse3 >= 3.0])
+ PKG_CHECK_MODULES([LIBYAML], [yaml-0.1 >= 0.1.7])
+ PKG_CHECK_MODULES([LIBNL], [libnl-3.0])
+ PKG_CHECK_MODULES([LIBNUMA], [numa >= 2.0])

--- a/recipe/fix-fuse3-rh.patch
+++ b/recipe/fix-fuse3-rh.patch
@@ -1,0 +1,10 @@
+--- a/retry_handler/rh.h
++++ b/retry_handler/rh.h
+@@ -147,7 +147,6 @@
+ 
+ 	pthread_t stats_thread;
+ 	struct fuse *stats_fuse;
+-	struct fuse_chan *stats_chan;
+ 	struct {
+ 		unsigned int spt_alloc;
+ 		unsigned int spt_freed;

--- a/recipe/fix-fuse3-stats.patch
+++ b/recipe/fix-fuse3-stats.patch
@@ -1,0 +1,207 @@
+--- a/retry_handler/stats.c
++++ b/retry_handler/stats.c
+@@ -5,8 +5,8 @@
+ #define FUSE_USE_VERSION 30
+ 
+ #include <pthread.h>
+-#include <fuse.h>
+-#include <fuse/fuse_common.h>
++#include <fuse3/fuse.h>
++#include <fuse3/fuse_common.h>
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <sys/types.h>
+@@ -23,7 +23,7 @@
+  * Define the permissions for reading any directory and update link count
+  * Link count of a directory is 2 + the number of directories immediately contained by it
+  */
+-static int stats_getattr(const char *path, struct stat *st)
++static int stats_getattr(const char *path, struct stat *st, struct fuse_file_info *fi)
+ {
+ 	st->st_uid = getuid();
+ 	st->st_gid = getgid();
+@@ -52,70 +52,70 @@
+  * Add both sub directories and files
+  */
+ static int stats_readdir(const char *path, void *buffer,
+-			 fuse_fill_dir_t filler, off_t offset,
+-			 struct fuse_file_info *fi)
++		fuse_fill_dir_t filler, off_t offset,
++		struct fuse_file_info *fi, enum fuse_readdir_flags flags)
+ {
+-	filler(buffer, ".", NULL, 0);
+-	filler(buffer, "..", NULL, 0);
++	filler(buffer, ".", NULL, 0, 0);
++	filler(buffer, "..", NULL, 0, 0);
+ 
+ 	if (!strcmp(path, "/")) {
+-		filler(buffer, "config", NULL, 0);
+-		filler(buffer, "spt_timeouts", NULL, 0);
+-		filler(buffer, "spt_timeouts_u", NULL, 0);
+-		filler(buffer, "spt_timeouts_o", NULL, 0);
+-		filler(buffer, "connections_cancelled", NULL, 0);
+-		filler(buffer, "pkts_cancelled_u", NULL, 0);
+-		filler(buffer, "pkts_cancelled_o", NULL, 0);
+-		filler(buffer, "cancel_no_matching_conn", NULL, 0);
+-		filler(buffer, "cancel_resource_busy", NULL, 0);
+-		filler(buffer, "cancel_trs_pend_rsp", NULL, 0);
+-		filler(buffer, "cancel_tct_closed", NULL, 0);
+-		filler(buffer, "nacks", NULL, 0);
+-		filler(buffer, "nack_no_target_trs", NULL, 0);
+-		filler(buffer, "nack_no_target_mst", NULL, 0);
+-		filler(buffer, "nack_no_target_conn", NULL, 0);
+-		filler(buffer, "nack_no_matching_conn", NULL, 0);
+-		filler(buffer, "nack_resource_busy", NULL, 0);
+-		filler(buffer, "nack_trs_pend_rsp", NULL, 0);
+-		filler(buffer, "nack_sequence_error", NULL, 0);
+-		filler(buffer, "sct_timeouts", NULL, 0);
+-		filler(buffer, "tct_timeouts", NULL, 0);
+-		filler(buffer, "accel_close_complete", NULL, 0);
+-		filler(buffer, "ignored_sct_timeouts", NULL, 0);
+-		filler(buffer, "srb_in_use", NULL, 0);
+-		filler(buffer, "spt_in_use", NULL, 0);
+-		filler(buffer, "smt_in_use", NULL, 0);
+-		filler(buffer, "sct_in_use", NULL, 0);
+-		filler(buffer, "trs_in_use", NULL, 0);
+-		filler(buffer, "mst_in_use", NULL, 0);
+-		filler(buffer, "tct_in_use", NULL, 0);
+-		filler(buffer, "rh_sct_status_change", NULL, 0);
+-		filler(buffer, "nid_value", NULL, 0);
+-		filler(buffer, "nid_tree_count", NULL, 0);
+-		filler(buffer, "max_nid_tree_count", NULL, 0);
+-		filler(buffer, "switch_tree_count", NULL, 0);
+-		filler(buffer, "max_switch_tree_count", NULL, 0);
+-		filler(buffer, "parked_nids", NULL, 0);
+-		filler(buffer, "max_parked_nids", NULL, 0);
+-		filler(buffer, "parked_switches", NULL, 0);
+-		filler(buffer, "max_parked_switches", NULL, 0);
++		filler(buffer, "config", NULL, 0, 0);
++		filler(buffer, "spt_timeouts", NULL, 0, 0);
++		filler(buffer, "spt_timeouts_u", NULL, 0, 0);
++		filler(buffer, "spt_timeouts_o", NULL, 0, 0);
++		filler(buffer, "connections_cancelled", NULL, 0, 0);
++		filler(buffer, "pkts_cancelled_u", NULL, 0, 0);
++		filler(buffer, "pkts_cancelled_o", NULL, 0, 0);
++		filler(buffer, "cancel_no_matching_conn", NULL, 0, 0);
++		filler(buffer, "cancel_resource_busy", NULL, 0, 0);
++		filler(buffer, "cancel_trs_pend_rsp", NULL, 0, 0);
++		filler(buffer, "cancel_tct_closed", NULL, 0, 0);
++		filler(buffer, "nacks", NULL, 0, 0);
++		filler(buffer, "nack_no_target_trs", NULL, 0, 0);
++		filler(buffer, "nack_no_target_mst", NULL, 0, 0);
++		filler(buffer, "nack_no_target_conn", NULL, 0, 0);
++		filler(buffer, "nack_no_matching_conn", NULL, 0, 0);
++		filler(buffer, "nack_resource_busy", NULL, 0, 0);
++		filler(buffer, "nack_trs_pend_rsp", NULL, 0, 0);
++		filler(buffer, "nack_sequence_error", NULL, 0, 0);
++		filler(buffer, "sct_timeouts", NULL, 0, 0);
++		filler(buffer, "tct_timeouts", NULL, 0, 0);
++		filler(buffer, "accel_close_complete", NULL, 0, 0);
++		filler(buffer, "ignored_sct_timeouts", NULL, 0, 0);
++		filler(buffer, "srb_in_use", NULL, 0, 0);
++		filler(buffer, "spt_in_use", NULL, 0, 0);
++		filler(buffer, "smt_in_use", NULL, 0, 0);
++		filler(buffer, "sct_in_use", NULL, 0, 0);
++		filler(buffer, "trs_in_use", NULL, 0, 0);
++		filler(buffer, "mst_in_use", NULL, 0, 0);
++		filler(buffer, "tct_in_use", NULL, 0, 0);
++		filler(buffer, "rh_sct_status_change", NULL, 0, 0);
++		filler(buffer, "nid_value", NULL, 0, 0);
++		filler(buffer, "nid_tree_count", NULL, 0, 0);
++		filler(buffer, "max_nid_tree_count", NULL, 0, 0);
++		filler(buffer, "switch_tree_count", NULL, 0, 0);
++		filler(buffer, "max_switch_tree_count", NULL, 0, 0);
++		filler(buffer, "parked_nids", NULL, 0, 0);
++		filler(buffer, "max_parked_nids", NULL, 0, 0);
++		filler(buffer, "parked_switches", NULL, 0, 0);
++		filler(buffer, "max_parked_switches", NULL, 0, 0);
+ 	} else if (!strcmp(path, "/config")) {
+-		filler(buffer, "config_file_path", NULL, 0);
+-		filler(buffer, "max_fabric_packet_age", NULL, 0);
+-		filler(buffer, "max_spt_retries", NULL, 0);
+-		filler(buffer, "max_no_matching_conn_retries", NULL, 0);
+-		filler(buffer, "max_resource_busy_retries", NULL, 0);
+-		filler(buffer, "max_trs_pend_rsp_retries", NULL, 0);
+-		filler(buffer, "max_batch_size", NULL, 0);
+-		filler(buffer, "initial_batch_size", NULL, 0);
+-		filler(buffer, "backoff_multiplier", NULL, 0);
+-		filler(buffer, "nack_backoff_start", NULL, 0);
+-		filler(buffer, "tct_wait_time", NULL, 0);
+-		filler(buffer, "pause_wait_time", NULL, 0);
+-		filler(buffer, "cancel_spt_wait_time", NULL, 0);
+-		filler(buffer, "peer_tct_free_wait_time", NULL, 0);
+-		filler(buffer, "down_nid_wait_time", NULL, 0);
+-		filler(buffer, "log_increment", NULL, 0);
++		filler(buffer, "config_file_path", NULL, 0, 0);
++		filler(buffer, "max_fabric_packet_age", NULL, 0, 0);
++		filler(buffer, "max_spt_retries", NULL, 0, 0);
++		filler(buffer, "max_no_matching_conn_retries", NULL, 0, 0);
++		filler(buffer, "max_resource_busy_retries", NULL, 0, 0);
++		filler(buffer, "max_trs_pend_rsp_retries", NULL, 0, 0);
++		filler(buffer, "max_batch_size", NULL, 0, 0);
++		filler(buffer, "initial_batch_size", NULL, 0, 0);
++		filler(buffer, "backoff_multiplier", NULL, 0, 0);
++		filler(buffer, "nack_backoff_start", NULL, 0, 0);
++		filler(buffer, "tct_wait_time", NULL, 0, 0);
++		filler(buffer, "pause_wait_time", NULL, 0, 0);
++		filler(buffer, "cancel_spt_wait_time", NULL, 0, 0);
++		filler(buffer, "peer_tct_free_wait_time", NULL, 0, 0);
++		filler(buffer, "down_nid_wait_time", NULL, 0, 0);
++		filler(buffer, "log_increment", NULL, 0, 0);
+ 	}
+ 
+ 	return 0;
+@@ -308,7 +308,7 @@
+ 	return size;
+ }
+ 
+-static int stats_truncate(const char *path, off_t size)
++static int stats_truncate(const char *path, off_t size, struct fuse_file_info *fi)
+ {
+ 	if (!strcmp(path, "/config/log_increment"))
+ 		return 0;
+@@ -372,18 +372,19 @@
+ 		goto free_args;
+ 	}
+ 
+-	rh->stats_chan = fuse_mount(rh_stats_dir, &args);
+-	if (rh->stats_chan == NULL) {
+-		rh_printf(rh, LOG_ERR,
+-			  "Mount to %s failed\n", rh_stats_dir);
++	rh->stats_fuse = fuse_new(&args, &ops, sizeof(ops), rh);
++	if (rh->stats_fuse == NULL) {
++		rh_printf(rh, LOG_ERR, "fuse_new failed\n");
+ 		ret = -1;
+ 		goto free_args;
+ 	}
+ 
+-	rh->stats_fuse = fuse_new(rh->stats_chan, NULL, &ops, sizeof(ops), rh);
+-	if (rh->stats_fuse == NULL) {
++	ret = fuse_mount(rh->stats_fuse, rh_stats_dir);
++	if (ret != 0) {
++		rh_printf(rh, LOG_ERR,
++				"Mount to %s failed\n", rh_stats_dir);
+ 		ret = -1;
+-		goto free_chan;
++		goto free_fuse;
+ 	}
+ 
+ 	ret = pthread_create(&rh->stats_thread, NULL, stats_fs, (void *)rh);
+@@ -396,8 +397,6 @@
+ 
+ free_fuse:
+ 	fuse_destroy(rh->stats_fuse);
+-free_chan:
+-	fuse_unmount(rh_stats_dir, rh->stats_chan);
+ free_args:
+ 	fuse_opt_free_args(&args);
+ err:
+@@ -410,7 +409,7 @@
+ 	int ret;
+ 
+ 	/* interrupt fuse_loop() */
+-	fuse_unmount(rh_stats_dir, fs_rh->stats_chan);
++	fuse_unmount(fs_rh->stats_fuse);
+ 
+ 	ret = pthread_join(fs_rh->stats_thread, &thread_rc);
+ 	if (ret)

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,9 +12,12 @@ source:
     patches:
       - fix-random.patch
       - fix-udp-header.patch
+      - fix-fuse3-configure.patch
+      - fix-fuse3-stats.patch
+      - fix-fuse3-rh.patch
 
 build:
-  number: 0
+  number: 1
   script: build.sh
   skip:
     - win
@@ -33,7 +36,7 @@ requirements:
     - pkg-config
   host:
     - libconfig
-    - libfuse <3.0
+    - libfuse >=3
     - libnl
     - libnuma
     - libsystemd0


### PR DESCRIPTION
The PR changes should allow the feedstock to build with libfuse 3.x (which provides libfuse3 functionality)

@conda-forge-admin, please rerender

-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
